### PR TITLE
Automatically set defaults for GitLab.com URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Flags:
 
 ### Minimal
 
+The repository `type` and `source` properties will be set automatically when `url` begins with `https://github.com`.  Below is a minimal config for a project hosted on GitHub.
+
 ```json
 {
   "domain": "4d63.com",

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Flags:
 
 ### Minimal
 
-The repository `type` and `source` properties will be set automatically when `url` begins with `https://github.com`.  Below is a minimal config for a project hosted on GitHub.
+The repository `type` and `source` properties will be set automatically when `url` begins with `https://github.com` or `https://gitlab.com`.  This minimizes the config required for projects hosted on either site.  Below is a minimal config for a project hosted on GitHub.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Flags:
 
 ### Minimal
 
-The repository `type` and `source` properties will be set automatically when `url` begins with `https://github.com` or `https://gitlab.com`.  This minimizes the config required for projects hosted on either site.  Below is a minimal config for a project hosted on GitHub.
+The repository `type` and `source` properties will be set automatically when `url` begins with `https://github.com` or `https://gitlab.com`. Below is a minimal config for a project hosted on GitHub.
 
 ```json
 {

--- a/config_test.go
+++ b/config_test.go
@@ -192,3 +192,95 @@ func TestParseConfigGithubComplete(t *testing.T) {
 		t.Errorf("Got config %#v, want %#v", c, e)
 	}
 }
+
+func TestParseConfigGitlabMinimal(t *testing.T) {
+	r := strings.NewReader(`{
+  "domain": "4d63.com",
+  "repositories": [
+    {
+      "prefix": "optional",
+      "subs": [
+        "template"
+      ],
+      "url": "https://gitlab.com/leighmcculloch/go-optional"
+    }
+  ]
+}`)
+
+	e := config{
+		Domain: "4d63.com",
+		Repositories: []repository{
+			{
+				Prefix: "optional",
+				Subs: []sub{
+					{Name: "template"},
+				},
+				URL: "https://gitlab.com/leighmcculloch/go-optional",
+			},
+		},
+	}
+
+	c, err := parseConfig(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(c, e) {
+		t.Errorf("Got config %#v, want %#v", c, e)
+	}
+}
+
+func TestParseConfigGitlabComplete(t *testing.T) {
+	r := strings.NewReader(`{
+  "domain": "4d63.com",
+  "repositories": [
+    {
+      "prefix": "optional",
+      "subs": [
+        "template"
+      ],
+      "type": "git",
+      "url": "https://gitlab.com/leighmcculloch/go-optional",
+      "source": {
+        "home": "https://gitlab.com/leighmcculloch/go-optional",
+        "dir": "https://gitlab.com/leighmcculloch/go-optional/tree/master{/dir}",
+        "file": "https://gitlab.com/leighmcculloch/go-optional/blob/master{/dir}/{file}#L{line}"
+      },
+      "website": {
+        "url": "https://gitlab.com/leighmcculloch/go-optional"
+      }
+    }
+  ]
+}`)
+
+	e := config{
+		Domain: "4d63.com",
+		Repositories: []repository{
+			{
+				Prefix: "optional",
+				Subs: []sub{
+					{Name: "template"},
+				},
+				Type: "git",
+				URL:  "https://gitlab.com/leighmcculloch/go-optional",
+				SourceURLs: sourceURLs{
+					Home: "https://gitlab.com/leighmcculloch/go-optional",
+					Dir:  "https://gitlab.com/leighmcculloch/go-optional/tree/master{/dir}",
+					File: "https://gitlab.com/leighmcculloch/go-optional/blob/master{/dir}/{file}#L{line}",
+				},
+				Website: website{
+					URL: "https://gitlab.com/leighmcculloch/go-optional",
+				},
+			},
+		},
+	}
+
+	c, err := parseConfig(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(c, e) {
+		t.Errorf("Got config %#v, want %#v", c, e)
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -101,7 +101,7 @@ func TestParseConfigHiddenPackages(t *testing.T) {
 	}
 }
 
-func TestParseConfigGitubMinimal(t *testing.T) {
+func TestParseConfigGithubMinimal(t *testing.T) {
 	r := strings.NewReader(`{
   "domain": "4d63.com",
   "repositories": [

--- a/generate_package.go
+++ b/generate_package.go
@@ -48,7 +48,8 @@ Source: <a href="{{.Repository.URL}}">{{.Repository.URL}}</a><br/>
 		homeURL = fmt.Sprintf("https://godoc.org/%s/%s", domain, pkg)
 	}
 
-	if strings.HasPrefix(r.URL, "https://github.com") {
+	if strings.HasPrefix(r.URL, "https://github.com") ||
+		strings.HasPrefix(r.URL, "https://gitlab.com") {
 		r.Type = "git"
 		r.SourceURLs = sourceURLs{
 			Home: r.URL,

--- a/generate_package.go
+++ b/generate_package.go
@@ -48,8 +48,7 @@ Source: <a href="{{.Repository.URL}}">{{.Repository.URL}}</a><br/>
 		homeURL = fmt.Sprintf("https://godoc.org/%s/%s", domain, pkg)
 	}
 
-	if strings.HasPrefix(r.URL, "https://github.com") ||
-		strings.HasPrefix(r.URL, "https://gitlab.com") {
+	if strings.HasPrefix(r.URL, "https://github.com") || strings.HasPrefix(r.URL, "https://gitlab.com") {
 		r.Type = "git"
 		r.SourceURLs = sourceURLs{
 			Home: r.URL,

--- a/generate_package_test.go
+++ b/generate_package_test.go
@@ -254,6 +254,76 @@ Sub-packages:<ul><li><a href="/pkg1/subpkg1">example.com/pkg1/subpkg1</a></li><l
 </html>`,
 			expectedErr: nil,
 		},
+		{
+			description: "gitlab defaults",
+			domain:      "example.com",
+			pkg:         "pkg1",
+			r: repository{
+				Prefix: "pkg1",
+				Subs:   []sub{{Name: "subpkg1"}, {Name: "subpkg2"}},
+				URL:    "https://gitlab.com/example/go-pkg1",
+			},
+			expectedOut: `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="go-import" content="example.com/pkg1 git https://gitlab.com/example/go-pkg1">
+<meta name="go-source" content="example.com/pkg1 https://gitlab.com/example/go-pkg1 https://gitlab.com/example/go-pkg1/tree/master{/dir} https://gitlab.com/example/go-pkg1/blob/master{/dir}/{file}#L{line}">
+<style>
+* { font-family: sans-serif; }
+body { margin-top: 0; }
+.content { display: inline-block; }
+code { display: block; font-family: monospace; font-size: 1em; background-color: #d5d5d5; padding: 1em; margin-bottom: 16px; }
+ul { margin-top: 16px; margin-bottom: 16px; }
+</style>
+</head>
+<body>
+<div class="content">
+<h2>example.com/pkg1</h2>
+<code>go get example.com/pkg1</code>
+<code>import "example.com/pkg1"</code>
+Home: <a href="https://godoc.org/example.com/pkg1">https://godoc.org/example.com/pkg1</a><br/>
+Source: <a href="https://gitlab.com/example/go-pkg1">https://gitlab.com/example/go-pkg1</a><br/>
+Sub-packages:<ul><li><a href="/pkg1/subpkg1">example.com/pkg1/subpkg1</a></li><li><a href="/pkg1/subpkg2">example.com/pkg1/subpkg2</a></li></ul></div>
+</body>
+</html>`,
+			expectedErr: nil,
+		},
+		{
+			description: "sub-package gitlab defaults",
+			domain:      "example.com",
+			pkg:         "pkg1/subpkg1",
+			r: repository{
+				Prefix: "pkg1",
+				Subs:   []sub{{Name: "subpkg1"}, {Name: "subpkg2"}},
+				URL:    "https://gitlab.com/example/go-pkg1",
+			},
+			expectedOut: `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="go-import" content="example.com/pkg1 git https://gitlab.com/example/go-pkg1">
+<meta name="go-source" content="example.com/pkg1 https://gitlab.com/example/go-pkg1 https://gitlab.com/example/go-pkg1/tree/master{/dir} https://gitlab.com/example/go-pkg1/blob/master{/dir}/{file}#L{line}">
+<style>
+* { font-family: sans-serif; }
+body { margin-top: 0; }
+.content { display: inline-block; }
+code { display: block; font-family: monospace; font-size: 1em; background-color: #d5d5d5; padding: 1em; margin-bottom: 16px; }
+ul { margin-top: 16px; margin-bottom: 16px; }
+</style>
+</head>
+<body>
+<div class="content">
+<h2>example.com/pkg1/subpkg1</h2>
+<code>go get example.com/pkg1/subpkg1</code>
+<code>import "example.com/pkg1/subpkg1"</code>
+Home: <a href="https://godoc.org/example.com/pkg1/subpkg1">https://godoc.org/example.com/pkg1/subpkg1</a><br/>
+Source: <a href="https://gitlab.com/example/go-pkg1">https://gitlab.com/example/go-pkg1</a><br/>
+Sub-packages:<ul><li><a href="/pkg1/subpkg1">example.com/pkg1/subpkg1</a></li><li><a href="/pkg1/subpkg2">example.com/pkg1/subpkg2</a></li></ul></div>
+</body>
+</html>`,
+			expectedErr: nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This adds a check for URLs that start with `https://gitlab.com` so they can be automatically configured.  It allows GitLab.com repositories to use the same minimal config as GitHub repositories.

fixes #3 