### PR TITLE
Fix double slashes in single module deployment

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,10 +28,14 @@ type repository struct {
 
 func (r repository) Packages() []string {
 	pkgs := []string{r.Prefix}
-	for _, s := range r.Subs {
-		pkgs = append(pkgs, path.Join(r.Prefix, s.Name))
+	for i := range r.Subs {
+		pkgs = append(pkgs, r.SubPath(i))
 	}
 	return pkgs
+}
+
+func (r repository) SubPath(i int) string {
+	return path.Join(r.Prefix, r.Subs[i].Name)
 }
 
 type sub struct {

--- a/generate_package.go
+++ b/generate_package.go
@@ -31,7 +31,7 @@ ul { margin-top: 16px; margin-bottom: 16px; }
 Home: <a href="{{.HomeURL}}">{{.HomeURL}}</a><br/>
 Source: <a href="{{.Repository.URL}}">{{.Repository.URL}}</a><br/>
 {{if .Repository.Subs -}}Sub-packages:<ul>{{end -}}
-{{range $_, $s := .Repository.Subs -}}{{if not $s.Hidden -}}<li><a href="/{{$.Repository.Prefix}}/{{$s.Name}}">{{$.Domain}}/{{$.Repository.Prefix}}/{{$s.Name}}</a></li>{{end -}}{{end -}}
+{{range $i, $s := .Repository.Subs -}}{{if not $s.Hidden -}}<li><a href="/{{$.Repository.SubPath $i}}">{{$.Domain}}/{{$.Repository.SubPath $i}}</a></li>{{end -}}{{end -}}
 {{if .Repository.Subs -}}</ul>{{end -}}
 </div>
 </body>

--- a/generate_package_test.go
+++ b/generate_package_test.go
@@ -424,6 +424,52 @@ Sub-packages:<ul><li><a href="/pkg1/subpkg1">example.com/pkg1/subpkg1</a></li><l
 </html>`,
 			expectedErr: nil,
 		},
+		{
+			description: "no top level pkg, no prefix",
+			domain:      "example.com",
+			docsDomain:  "",
+			pkg:         "",
+			r: repository{
+				Prefix: "",
+				Subs:   []sub{{Name: "subpkg1"}, {Name: "subpkg2"}},
+				Type:   "git",
+				URL:    "https://github.com/example/go-pkg1",
+				SourceURLs: sourceURLs{
+					Home: "https://github.com/example/go-pkg1",
+					Dir:  "https://github.com/example/go-pkg1/tree/branch{/dir}",
+					File: "https://github.com/example/go-pkg1/blob/branch{/dir}/{file}#L{line}",
+				},
+				Website: website{
+					URL: "https://www.example.com",
+				},
+			},
+			expectedOut: `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>example.com/</title>
+<meta name="go-import" content="example.com/ git https://github.com/example/go-pkg1">
+<meta name="go-source" content="example.com/ https://github.com/example/go-pkg1 https://github.com/example/go-pkg1/tree/branch{/dir} https://github.com/example/go-pkg1/blob/branch{/dir}/{file}#L{line}">
+<style>
+* { font-family: sans-serif; }
+body { margin-top: 0; }
+.content { display: inline-block; }
+code { display: block; font-family: monospace; font-size: 1em; background-color: #d5d5d5; padding: 1em; margin-bottom: 16px; }
+ul { margin-top: 16px; margin-bottom: 16px; }
+</style>
+</head>
+<body>
+<div class="content">
+<h2>example.com/</h2>
+<code>go get example.com/</code>
+<code>import "example.com/"</code>
+Home: <a href="https://www.example.com">https://www.example.com</a><br/>
+Source: <a href="https://github.com/example/go-pkg1">https://github.com/example/go-pkg1</a><br/>
+Sub-packages:<ul><li><a href="//subpkg1">example.com//subpkg1</a></li><li><a href="//subpkg2">example.com//subpkg2</a></li></ul></div>
+</body>
+</html>`,
+			expectedErr: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/generate_package_test.go
+++ b/generate_package_test.go
@@ -425,7 +425,7 @@ Sub-packages:<ul><li><a href="/pkg1/subpkg1">example.com/pkg1/subpkg1</a></li><l
 			expectedErr: nil,
 		},
 		{
-			description: "no top level pkg, no prefix",
+			description: "single module deployment that has no 'prefix'",
 			domain:      "example.com",
 			docsDomain:  "",
 			pkg:         "",
@@ -465,7 +465,7 @@ ul { margin-top: 16px; margin-bottom: 16px; }
 <code>import "example.com/"</code>
 Home: <a href="https://www.example.com">https://www.example.com</a><br/>
 Source: <a href="https://github.com/example/go-pkg1">https://github.com/example/go-pkg1</a><br/>
-Sub-packages:<ul><li><a href="//subpkg1">example.com//subpkg1</a></li><li><a href="//subpkg2">example.com//subpkg2</a></li></ul></div>
+Sub-packages:<ul><li><a href="/subpkg1">example.com/subpkg1</a></li><li><a href="/subpkg2">example.com/subpkg2</a></li></ul></div>
 </body>
 </html>`,
 			expectedErr: nil,


### PR DESCRIPTION
### What
When a prefix is empty for a module, make it so the path generated for its sub-packages do not contain multiple slashes.

### Why
The prefix is empty in some configurations where a single module is being hosted at the root domain. The package paths were being built using simple string concatenation but when the prefix is empty this results in multiple slashes. e.g. `//`

The stdlib `path.Join` function will join the path components and it will omit components (and the slash required to separate them) if the component is empty.

Close https://github.com/leighmcculloch/vangen/issues/16