### PR TITLE
Fix import prefix trailing slash

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,6 +26,14 @@ type repository struct {
 	Website    website    `json:"website"`
 }
 
+func (r repository) PrefixPath() string {
+	if r.Prefix == "" {
+		return ""
+	} else {
+		return "/" + r.Prefix
+	}
+}
+
 func (r repository) Packages() []string {
 	pkgs := []string{r.Prefix}
 	for i := range r.Subs {
@@ -75,7 +83,6 @@ type website struct {
 
 func parseConfig(r io.Reader) (config, error) {
 	bytes, err := ioutil.ReadAll(r)
-
 	if err != nil {
 		return config{}, err
 	}

--- a/generate_package.go
+++ b/generate_package.go
@@ -13,8 +13,8 @@ func generate_package(w io.Writer, domain, docsDomain, pkg string, r repository)
 <head>
 <meta charset="utf-8">
 <title>{{.Domain}}/{{.Package}}</title>
-<meta name="go-import" content="{{.Domain}}/{{.Repository.Prefix}} {{.Repository.Type}} {{.Repository.URL}}">
-<meta name="go-source" content="{{.Domain}}/{{.Repository.Prefix}} {{.Repository.SourceURLs.Home}} {{.Repository.SourceURLs.Dir}} {{.Repository.SourceURLs.File}}">
+<meta name="go-import" content="{{.Domain}}{{.Repository.PrefixPath}} {{.Repository.Type}} {{.Repository.URL}}">
+<meta name="go-source" content="{{.Domain}}{{.Repository.PrefixPath}} {{.Repository.SourceURLs.Home}} {{.Repository.SourceURLs.Dir}} {{.Repository.SourceURLs.File}}">
 <style>
 * { font-family: sans-serif; }
 body { margin-top: 0; }

--- a/generate_package_test.go
+++ b/generate_package_test.go
@@ -448,8 +448,8 @@ Sub-packages:<ul><li><a href="/pkg1/subpkg1">example.com/pkg1/subpkg1</a></li><l
 <head>
 <meta charset="utf-8">
 <title>example.com/</title>
-<meta name="go-import" content="example.com/ git https://github.com/example/go-pkg1">
-<meta name="go-source" content="example.com/ https://github.com/example/go-pkg1 https://github.com/example/go-pkg1/tree/branch{/dir} https://github.com/example/go-pkg1/blob/branch{/dir}/{file}#L{line}">
+<meta name="go-import" content="example.com git https://github.com/example/go-pkg1">
+<meta name="go-source" content="example.com https://github.com/example/go-pkg1 https://github.com/example/go-pkg1/tree/branch{/dir} https://github.com/example/go-pkg1/blob/branch{/dir}/{file}#L{line}">
 <style>
 * { font-family: sans-serif; }
 body { margin-top: 0; }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,12 @@
 module 4d63.com/vangen
 
+go 1.21.0
+
+require github.com/sergi/go-diff v1.0.0
+
 require (
-	github.com/sergi/go-diff v1.0.0
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
 )


### PR DESCRIPTION
### What
Change the import prefix that gets rendered when the import prefix is a domain only with no path, to have no trailing slash.

### Why
The templates that generate the pages always insert a slash at the end of the domain for the import prefix assuming a path follows, and when a path doesn't follow that results in a trailing slash.

Go import paths don't usually has trailing slashes on the end of the import path.

I suspect this might be the cause of why import prefixes for repos that don't have a path are not integrating well with pkg.go.dev.

Close #19